### PR TITLE
chore: add Makefile targets for docker helpers

### DIFF
--- a/mongodb/CHANGELOG.md
+++ b/mongodb/CHANGELOG.md
@@ -22,6 +22,56 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 2026-01-14 | 🧹 chore: Makefile docker helpers
+
+### 📄 Summary
+- Added Makefile targets for Docker helpers and CSV ingestion.
+
+### 📁 Files Changed
+- `Makefile`
+- `CHANGELOG.md`
+
+### 🧠 Rationale
+- Provide consistent CLI ergonomics for Docker workflows.
+
+### 🔄 Behavior / Compatibility Implications
+- Adds new Makefile targets only.
+
+### 🧪 Testing Recommendations
+- `make docker-up`
+- `make ingest CSV=out/scenarios/list_of_objects_explode/output.csv`
+- `make docker-down`
+
+### 📌 Follow‑ups
+- None.
+
+## 2026-01-14 | 🧹 chore: docker helper scripts and docs
+
+### 📄 Summary
+- Added helper scripts to start/stop MongoDB and ingest arbitrary CSV files.
+- Expanded README with a Docker helpers section.
+
+### 📁 Files Changed
+- `scripts/docker_up.sh`
+- `scripts/docker_down.sh`
+- `scripts/ingest_csv.sh`
+- `README.md`
+- `CHANGELOG.md`
+
+### 🧠 Rationale
+- Make Docker workflows repeatable and developer-friendly.
+
+### 🔄 Behavior / Compatibility Implications
+- Adds new scripts; no runtime changes to existing flows.
+
+### 🧪 Testing Recommendations
+- `scripts/docker_up.sh`
+- `scripts/ingest_csv.sh out/scenarios/list_of_objects_explode/output.csv`
+- `scripts/docker_down.sh`
+
+### 📌 Follow‑ups
+- None.
+
 ## 2026-01-14 | 🧹 chore: CI workflow and scenario upgrades
 
 ### 📄 Summary

--- a/mongodb/Makefile
+++ b/mongodb/Makefile
@@ -1,12 +1,15 @@
 PYTHON ?= python3
 
-.PHONY: help install test scenarios
+.PHONY: help install test scenarios docker-up docker-down ingest
 
 help:
 	@echo "Targets:"
 	@echo "  install    Install Python deps"
 	@echo "  test       Run unit tests with coverage"
 	@echo "  scenarios  Run JSON flattening scenarios"
+	@echo "  docker-up  Start MongoDB container"
+	@echo "  docker-down  Stop containers and remove volumes"
+	@echo "  ingest     Ingest CSV via docker (CSV=path/to.csv)"
 
 install:
 	$(PYTHON) -m pip install -r requirements.txt
@@ -16,3 +19,13 @@ test:
 
 scenarios:
 	$(PYTHON) scripts/run_scenarios.py
+
+docker-up:
+	scripts/docker_up.sh
+
+docker-down:
+	scripts/docker_down.sh
+
+ingest:
+	@if [ -z "$(CSV)" ]; then echo "Usage: make ingest CSV=path/to.csv"; exit 1; fi
+	scripts/ingest_csv.sh $(CSV)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -81,6 +81,32 @@ scripts/seed_mongo.sh multi_path_explosion
 mongosh mongodb://localhost:27017
 ```
 
+## Docker helpers
+
+Start only the MongoDB service:
+
+```bash
+scripts/docker_up.sh
+```
+
+Stop containers and remove volumes:
+
+```bash
+scripts/docker_down.sh
+```
+
+Ingest any CSV file into MongoDB:
+
+```bash
+scripts/ingest_csv.sh out/scenarios/list_of_objects_explode/output.csv
+```
+
+The Docker compose file mounts `CSV_PATH` into the ingest container, so you can also run:
+
+```bash
+CSV_PATH=../out/scenarios/multi_path_explosion/output.csv docker compose -f docker/docker-compose.yml up --build --abort-on-container-exit ingest
+```
+
 ## Scenarios
 
 See `docs/scenarios.md` for intermediate and advanced cases and how they map to output CSV.

--- a/mongodb/scripts/docker_down.sh
+++ b/mongodb/scripts/docker_down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+docker compose -f docker/docker-compose.yml down -v

--- a/mongodb/scripts/docker_up.sh
+++ b/mongodb/scripts/docker_up.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+docker compose -f docker/docker-compose.yml up -d mongo

--- a/mongodb/scripts/ingest_csv.sh
+++ b/mongodb/scripts/ingest_csv.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+csv_path="${1:-}"
+if [ -z "$csv_path" ]; then
+  echo "Usage: scripts/ingest_csv.sh <path-to-csv>"
+  exit 1
+fi
+
+if [ ! -f "$csv_path" ]; then
+  echo "CSV not found: $csv_path"
+  exit 1
+fi
+
+CSV_PATH="../$csv_path" docker compose -f docker/docker-compose.yml up --build --abort-on-container-exit ingest


### PR DESCRIPTION
This pull request introduces new Docker helper scripts and Makefile targets to streamline MongoDB workflows, making it easier for developers to start/stop containers and ingest CSV files. Documentation has been updated to reflect these improvements, ensuring repeatable and user-friendly operations. No changes affect runtime behavior or existing flows.

**Docker workflow enhancements:**

* Added three helper scripts: `docker_up.sh` to start MongoDB, `docker_down.sh` to stop containers and remove volumes, and `ingest_csv.sh` to ingest arbitrary CSV files via Docker. [[1]](diffhunk://#diff-d0cc0a82e7a126beeabdd3aff0729bc0b629acd94e3b8cb264d9034af8814d28R1-R7) [[2]](diffhunk://#diff-8056d89ab0ca4f3bab2a338d523720e9b6ee71c9056f3e9213e2acc9f651fdf3R1-R7) [[3]](diffhunk://#diff-212504ce08cca7feeb591c6353335f5c213e9730cdccfe123dd0c9bb78593a3fR1-R18)
* Updated the `Makefile` with new targets (`docker-up`, `docker-down`, and `ingest`) to invoke these scripts, providing consistent CLI ergonomics for Docker workflows. [[1]](diffhunk://#diff-f4adf86c4df19e112ecb9d1cea0c4db2a6379719c47eb56363f498696719a3b7L3-R12) [[2]](diffhunk://#diff-f4adf86c4df19e112ecb9d1cea0c4db2a6379719c47eb56363f498696719a3b7R22-R31)

**Documentation updates:**

* Expanded the `README.md` with a new section detailing the Docker helper scripts and usage examples, improving onboarding and developer experience.

**Changelog:**

* Documented all new scripts, Makefile targets, and rationale in `CHANGELOG.md` for traceability.